### PR TITLE
test: 알림 신규 여부 체크 서비스 단위 테스트 및 주석 추가

### DIFF
--- a/api/src/test/java/com/fc/service/CheckNewNotificationServiceTest.java
+++ b/api/src/test/java/com/fc/service/CheckNewNotificationServiceTest.java
@@ -1,0 +1,108 @@
+package com.fc.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CheckNewNotificationServiceTest {
+
+    @Mock
+    private NotificationGetService notificationGetService;
+
+    @Mock
+    private LastReadAtService lastReadAtService;
+
+    @InjectMocks // 만든 mock들을 CheckNewNotificationService 안에 주입
+    private CheckNewNotificationService checkNewNotificationService;
+
+    @Test
+    void notification_not_fount_false_return() {
+        // 시나리오
+        // 알림 자체가 하나도 없는 경우
+        // latestUpdatedAt == null 이라고 가정
+        // 이런 경우에는 "새 알림 없음" -> false 가 나와야 한다.
+        long userId = 1L;
+
+        boolean result = checkNewNotificationService.checkNewNotification(userId);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void notification_one_notRead_true_return() {
+        // 시나리오
+        // 알림은 존재함 (latestUpdatedAt != null)
+        // 하지만 사용자가 한 번도 읽은 적이 없음 (lastReadAt == null)
+        // 이런 경우에는 "읽지 않은 알림이 있다" -> true 가 되어야 한다.
+        long userId = 1L;
+        Instant latestUpdatedAt = Instant.parse("2025-11-29T10:00:00Z");
+
+        when(notificationGetService.getLatestUpdatedAt(anyLong()))
+                .thenReturn(latestUpdatedAt);
+        when(lastReadAtService.getLastReadAt(anyLong()))
+                .thenReturn(null);
+
+        // when
+        boolean result = checkNewNotificationService.checkNewNotification(userId);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    void lastTime_prevUpdate_notification_true_return() {
+        // 시나리오
+        // 알림이 존재함
+        // 사용자가 마지막으로 읽은 시간(lastReadAt)보다
+        // 더 나중에 업데이트된 알림(latestUpdatedAt)이 있음
+        // 즉, 읽은 이후에 새 알림이 도착한 상태 -> true 여야 함
+        long userId = 1L;
+        Instant latestUpdatedAt = Instant.parse("2025-01-01T10:00:00Z");
+        Instant lastReadAt = Instant.parse("2025-01-01T09:00:00Z");
+
+        when(notificationGetService.getLatestUpdatedAt(userId))
+                .thenReturn(latestUpdatedAt);
+        when(lastReadAtService.getLastReadAt(userId))
+                .thenReturn(lastReadAt);
+
+        // when
+        boolean result = checkNewNotificationService.checkNewNotification(userId);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    void lastTime_more_recent_false_return() {
+        // 시나리오
+        // 알림이 존재하긴 하지만,
+        // 사용자가 마지막으로 읽은 시간(lastReadAt)이
+        // 최신 알림 시간(latestUpdatedAt)보다 "더 나중"인 경우
+        // 즉, 사용자가 가장 마지막 알림까지 이미 다 읽은 상태 -> false 여야 함
+        long userId = 1L;
+        // 최신 알림 업데이트 시각은 10:00
+        Instant latestUpdatedAt = Instant.parse("2025-01-01T10:00:00Z");
+        // 사용자가 마지막으로 읽은 시각은 그보다 늦은 11:00
+        Instant lastReadAt = Instant.parse("2025-01-01T11:00:00Z");
+
+        when(notificationGetService.getLatestUpdatedAt(userId))
+                .thenReturn(latestUpdatedAt);
+        when(lastReadAtService.getLastReadAt(userId))
+                .thenReturn(lastReadAt);
+
+        // when
+        boolean result = checkNewNotificationService.checkNewNotification(userId);
+
+        // then
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
## 개요
알림 신규 여부를 판단하는 `CheckNewNotificationService`에 대한 단위 테스트를 추가하고,
각 케이스별 의도를 주석으로 명확히 정리했습니다.

## 주요 변경 사항
- 알림이 하나도 없을 때 `false`를 반환하는 테스트 추가
  - `notification_not_fount_false_return`
- 알림은 있지만 한 번도 읽지 않은 경우 `true`를 반환하는 테스트 추가
  - `notification_one_notRead_true_return`
- 마지막 읽은 시간이 최신 알림 시간보다 이전인 경우 `true`를 반환하는 테스트 추가
  - `lastTime_prevUpdate_notification_true_return`
- 마지막 읽은 시간이 최신 알림 시간보다 이후인 경우 `false`를 반환하는 테스트 추가
  - `lastTime_more_recent_false_return`
- 각 테스트 메서드에 시나리오/의도 주석 추가

## 테스트 방법
- 로컬에서 단위 테스트 실행
  - IntelliJ: 해당 테스트 클래스에서 `Run 'CheckNewNotificationServiceTest'`

## 비고
- 신규 알림 여부 판단 로직의 분기(알림 없음, 한 번도 읽지 않음, 읽은 이후 새 알림 여부)를 명시적으로 검증할 수 있게 되었습니다.
- 이후 알림 관련 로직 변경 시 회귀 테스트 용도로 활용 가능합니다.